### PR TITLE
Bug Fix for Cupola

### DIFF
--- a/src/main/java/mod/steamnsteel/block/machine/CupolaBlock.java
+++ b/src/main/java/mod/steamnsteel/block/machine/CupolaBlock.java
@@ -69,7 +69,7 @@ public class CupolaBlock extends SteamNSteelMachineBlock implements ITileEntityP
             te = world.getTileEntity(x, y - 1, z);
         }
 
-        if (((CupolaTE) te).isActive())
+        if ((te != null) && ((CupolaTE) te).isActive())
             return 15;
 
         return super.getLightValue(world, x, y, z);

--- a/src/main/java/mod/steamnsteel/tileentity/CupolaTE.java
+++ b/src/main/java/mod/steamnsteel/tileentity/CupolaTE.java
@@ -58,7 +58,7 @@ public class CupolaTE extends TileEntity implements ISidedInventory
     private static final String ITEM_COOK_TIME = "itemCookTime";
 
     private final Inventory inventory = new Inventory(INVENTORY_SIZE);
-    private Optional<Inventory> masterInventory = Optional.fromNullable(null); // the inventory of the block below, if this block is a slave
+    private Optional<Inventory> masterInventory = Optional.absent(); // the inventory of the block below, if this block is a slave
     private int deviceCookTime;
     private int fuelBurnTime;
     private int itemCookTime;

--- a/src/main/java/mod/steamnsteel/tileentity/CupolaTE.java
+++ b/src/main/java/mod/steamnsteel/tileentity/CupolaTE.java
@@ -58,7 +58,7 @@ public class CupolaTE extends TileEntity implements ISidedInventory
     private static final String ITEM_COOK_TIME = "itemCookTime";
 
     private final Inventory inventory = new Inventory(INVENTORY_SIZE);
-    private Optional<Inventory> masterInventory = null; // the inventory of the block below, if this block is a slave
+    private Optional<Inventory> masterInventory = Optional.fromNullable(null); // the inventory of the block below, if this block is a slave
     private int deviceCookTime;
     private int fuelBurnTime;
     private int itemCookTime;


### PR DESCRIPTION
Fixed getLightValue bug(occurs with block next to slave(top half) on break of bottom block)
Fix null reference on "Optional<Inventory> masterInventory"
