### PR TITLE
Delay loading of schematics until the world has loaded. 

### DIFF
--- a/src/main/java/mod/steamnsteel/world/SchematicLoader.java
+++ b/src/main/java/mod/steamnsteel/world/SchematicLoader.java
@@ -158,7 +158,6 @@ public class SchematicLoader
             return;
         }
 
-        _logger.info(String.format("%s - Rendering Chunk (%d, %d) ", System.currentTimeMillis(), chunkX, chunkZ));
 
         final int minX = originX;
         final int maxX = originX + schematic.getWidth();

--- a/src/main/java/mod/steamnsteel/world/WorldGen.java
+++ b/src/main/java/mod/steamnsteel/world/WorldGen.java
@@ -31,6 +31,7 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.terraingen.OreGenEvent;
 import net.minecraftforge.event.terraingen.PopulateChunkEvent;
 import net.minecraftforge.event.terraingen.TerrainGen;
+import net.minecraftforge.event.world.WorldEvent;
 import java.util.List;
 
 import static net.minecraftforge.event.terraingen.OreGenEvent.GenerateMinable.EventType.CUSTOM;
@@ -47,7 +48,6 @@ public enum WorldGen
     public static void init()
     {
         createOreGenerators();
-        createStructureGenerators();
         register();
         RetroGenHandler.register();
     }
@@ -86,10 +86,13 @@ public enum WorldGen
         }
     }
 
-    private static void createStructureGenerators() {
+    @SubscribeEvent
+    public void OnWorldStarted(WorldEvent.Load worldLoadEvent) {
+        structureGens.clear();
         final RemnantRuinsGenerator ruinsGenerator = new RemnantRuinsGenerator();
         structureGens.add(ruinsGenerator);
     }
+
 
     @SuppressWarnings("MethodMayBeStatic")
     @SubscribeEvent

--- a/src/main/java/mod/steamnsteel/world/structure/StructureChunkGenerator.java
+++ b/src/main/java/mod/steamnsteel/world/structure/StructureChunkGenerator.java
@@ -28,7 +28,12 @@ public class StructureChunkGenerator
 
     public void generate()
     {
-        Logger.info("Creating schematic at %d, %d", intersection.getX(), intersection.getY());
+
+        if (!ruin.hasGenerationStarted())
+        {
+            Logger.info("Creating Structure (type:%s) at %d, %d", ruin.schematic.resource, intersection.getX(), intersection.getY());
+            ruin.setGenerationStarted();
+        }
 
         if (ruin.height == null) {
             Chunk chunk = world.getChunkFromChunkCoords(chunkX, chunkZ);

--- a/src/main/java/mod/steamnsteel/world/structure/remnantruins/Ruin.java
+++ b/src/main/java/mod/steamnsteel/world/structure/remnantruins/Ruin.java
@@ -10,6 +10,7 @@ public class Ruin
     public final RuinSchematic schematic;
     public final Point location;
     public Integer height;
+    private boolean generationStarted;
 
     public Ruin(RuinLevel ruinLevel, int ruinX, int ruinZ, RuinSchematic ruinSchematic)
     {
@@ -37,5 +38,13 @@ public class Ruin
                 chunkRect.getY() > (bounds.getY() + bounds.getHeight()) ||
                 (chunkRect.getY() + chunkRect.getHeight()) < bounds.getY()
         );
+    }
+
+    public boolean hasGenerationStarted() {
+        return generationStarted;
+    }
+
+    public void setGenerationStarted() {
+        generationStarted = true;
     }
 }


### PR DESCRIPTION
This ensures that the ID map should be correct.
